### PR TITLE
Fixed a minor bug when using this in conjunction with search index

### DIFF
--- a/content/content.settings.php
+++ b/content/content.settings.php
@@ -130,7 +130,7 @@ Class contentExtensionConfigurationSettings extends AdministrationPage{
 				$label = Widget::Label(ucfirst(str_replace('_', ' ', $setting_name)));
 				$label->appendChild(Widget::Input('settings[' . $count . '][group]', $setting_group, 'hidden'));
 				$label->appendChild(Widget::Input('settings[' . $count . '][name]', $setting_name, 'hidden'));
-				$label->appendChild(Widget::Input('settings[' . $count . '][value]', $setting_value));
+				$label->appendChild(Widget::Input('settings[' . $count . '][value]', htmlspecialchars($setting_value)));
 				$fieldset->appendChild($label);
 				
 				$count++;


### PR DESCRIPTION
If any of the parameters contained special characters (such as ") then this was reflected into the html causing values to change when saved. This was especially noticed when used with the search index as the index field contained numerous double quotes.
